### PR TITLE
Fix issue when $_SERVER['argv'] is not set

### DIFF
--- a/src/Traits/ConsoleTrait.php
+++ b/src/Traits/ConsoleTrait.php
@@ -111,6 +111,6 @@ trait ConsoleTrait
      */
     private function isPrintable($force = true): bool
     {
-        return !($force === false && strpos($_SERVER['argv'][0], 'phpunit') !== false);
+        return !($force === false && strpos(($_SERVER['argv'][0]) ?? null, 'phpunit') !== false);
     }
 }


### PR DESCRIPTION
I was getting an error saying that `Undefined index: argv` was not set. This patch will check if `argv` is set and if not will just set it to `null` which seems to work locally.