### PR TITLE
Replaced http URLs with https

### DIFF
--- a/src/Traits/ReferralTrait.php
+++ b/src/Traits/ReferralTrait.php
@@ -7,7 +7,7 @@ trait ReferralTrait
     /**
      * @var string
      */
-    protected $referralUrl = 'http://partners.api.skyscanner.net/apiservices/referral/v1.0/';
+    protected $referralUrl = 'https://partners.api.skyscanner.net/apiservices/referral/v1.0/';
 
     /**
      * @param $country

--- a/src/Traits/RequestTrait.php
+++ b/src/Traits/RequestTrait.php
@@ -13,7 +13,7 @@ trait RequestTrait
     /**
      * @var string
      */
-    protected $url = 'http://partners.api.skyscanner.net/apiservices';
+    protected $url = 'https://partners.api.skyscanner.net/apiservices';
 
     /**
      * @var string

--- a/src/TravelService.php
+++ b/src/TravelService.php
@@ -98,7 +98,7 @@ abstract class TravelService
      *
      * @var string
      */
-    protected $url = 'http://partners.api.skyscanner.net/apiservices/';
+    protected $url = 'https://partners.api.skyscanner.net/apiservices/';
 
     /**
      * SkyScanner Service URI

--- a/tests/Traits/ReferralTraitTest.php
+++ b/tests/Traits/ReferralTraitTest.php
@@ -16,7 +16,7 @@ class ReferralTraitTest extends TestCase
     {
         $outboundDate = date('Y-m-d', strtotime('+1 month'));
         $url = $this->getReferralLinkByParameters('TR', 'TRY', 'tr-TR', 'SAW', 'DLM', $outboundDate, null, API_KEY_1);
-        $this->assertEquals('http://partners.api.skyscanner.net/apiservices/referral/v1.0/TR/TRY/tr-TR/SAW/DLM/' .
+        $this->assertEquals('https://partners.api.skyscanner.net/apiservices/referral/v1.0/TR/TRY/tr-TR/SAW/DLM/' .
             $outboundDate . '?apiKey=' . substr(API_KEY_1, 0, 16), $url);
     }
 
@@ -36,7 +36,7 @@ class ReferralTraitTest extends TestCase
         $outboundDate = date('Y-m-d', strtotime('+1 month'));
         $inboundDate = date('Y-m-d', strtotime('+2 month'));
         $url = $this->getReferralLinkByArrayOfParameters(['TR', 'TRY', 'tr-TR', 'SAW', 'DLM', $outboundDate, $inboundDate], API_KEY_1);
-        $this->assertEquals('http://partners.api.skyscanner.net/apiservices/referral/v1.0/TR/TRY/tr-TR/SAW/DLM/' .
+        $this->assertEquals('https://partners.api.skyscanner.net/apiservices/referral/v1.0/TR/TRY/tr-TR/SAW/DLM/' .
             $outboundDate . '/' . $inboundDate . '?apiKey=' . substr(API_KEY_1, 0, 16), $url);
     }
 }

--- a/tests/Travel/Flights/BrowseCacheTest.php
+++ b/tests/Travel/Flights/BrowseCacheTest.php
@@ -16,7 +16,7 @@ class BrowseCacheTest extends TestCase
         $cache = $this->getBrowseCache();
         [$url, $parameters] = $cache->getRequestUrlAndParameters($cache->getUrl(), true);
         $this->assertNotEmpty($parameters);
-        $this->assertEquals('http://partners.api.skyscanner.net/apiservices/browsequotes/v1.0/GB/GBP/en-GB/LHR/IST/' . date('Y-m-d', strtotime('+1 week')) . '/?apiKey=' . $cache->getParameter('apiKey'), $url);
+        $this->assertEquals('https://partners.api.skyscanner.net/apiservices/browsequotes/v1.0/GB/GBP/en-GB/LHR/IST/' . date('Y-m-d', strtotime('+1 week')) . '/?apiKey=' . $cache->getParameter('apiKey'), $url);
     }
 
     /**


### PR DESCRIPTION
Updated URL addresses for Skyscanner calls so now all of them use HTTPS.

From Skyscanner:
`We officially stopped supporting HTTP over a year ago but have still been responding to requests.  From 30th November 2021 onwards we will only accept requests via HTTPS due to security reasons. `